### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,7 +354,7 @@ jobs:
         uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d # tag=v1.0.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --all-targets --all-features -- --deny clippy::all --warn clippy::pedantic --warn clippy::cargo
+          args: --workspace --all-targets --all-features -- --deny clippy::all --deny clippy::pedantic --deny clippy::cargo
           name: Clippy report
 
   docker-build:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -36,6 +36,6 @@ jobs:
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
-        uses: github/codeql-action/upload-sarif@904260d7d935dff982205cbdb42025ce30b7a34f # tag=v2.1.24
+        uses: github/codeql-action/upload-sarif@86f3159a697a097a813ad9bfa0002412d97690a4 # tag=v2.1.25
         with:
           sarif_file: semgrep.sarif

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "autoheal-rs"
 # don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
 edition = "2021"
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 authors = ["Kristof Mattei"]
 description = "Rust end-to-end application"
 license-file = "LICENSE"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.63.0@sha256:54f17dc625ed83d3fc7dee68d5eac4e1977de40e72d909bcdb50cc55a462779d as builder
+FROM rust:1.64.0@sha256:be7a002254f0de0c3f2f90c4d2a11c6d6d48c28eac8065111d3a2c38785f3300 as builder
 
 ENV TARGET=x86_64-unknown-linux-musl
 RUN rustup target add ${TARGET}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.63.0"
+channel = "1.64.0"
 components = [ "cargo", "clippy", "rustfmt"  ]
 profile = "minimal"


### PR DESCRIPTION
- chore(deps): update github/codeql-action action to v2.1.25
- chore(deps): update rust to v1.64.0
- fix: deny stuff, nobody reads warnings
