### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          VERSION="$(cog bump --auto --dry-run)"
+          VERSION="$(cog bump --auto --dry-run || true)"
 
           if [[ -z $VERSION ]]; then
               VERSION="$(git describe --tags "$(git rev-list --tags --max-count=1)")"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "autoheal-rs"
 # don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
 edition = "2021"
-rust-version = "1.66.0"
+rust-version = "1.66.1"
 authors = ["Kristof Mattei"]
 description = "Rust end-to-end application"
 license-file = "LICENSE"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.66.0@sha256:7d80aa9030031d47cc004be6cbf5135af74af47751cdefe4e77679be55599f14 as builder
+FROM rust:1.66.1@sha256:954e0fa7aba70b3c6cafeb3c138f664b70e6e4276a367a274c3212eb53c42242 as builder
 
 ENV TARGET=x86_64-unknown-linux-musl
 RUN rustup target add ${TARGET}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.66.0"
+channel = "1.66.1"
 components = ["cargo", "clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
- chore(deps): update rust:1.66.0 docker digest to 7d80aa9
- fix: prevent cog throwing an error which causes script termination
- chore(deps): update rust to v1.66.1
- chore: bump package-lock.json
