### PR TITLE
update from upstream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,19 +10,19 @@
       "license": "ISC",
       "devDependencies": {
         "@actions/tool-cache": "^2.0.1",
-        "@semantic-release/changelog": "^6.0.1",
+        "@semantic-release/changelog": "^6.0.2",
         "@semantic-release/commit-analyzer": "^9.0.2",
-        "@semantic-release/github": "^8.0.5",
+        "@semantic-release/github": "^8.0.7",
         "@semantic-release/release-notes-generator": "^10.0.3",
         "conventional-changelog-conventionalcommits": "^5.0.0",
-        "prettier": "^2.7.1",
-        "semantic-release": "^20.0.0",
-        "semver": "^7.3.7",
+        "prettier": "^2.8.4",
+        "semantic-release": "^20.1.0",
+        "semver": "^7.3.8",
         "serialize-error": "^11.0.0"
       },
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
+        "node": ">=v18.14.0",
+        "npm": ">=9.4.2"
       }
     },
     "node_modules/@actions/core": {
@@ -5221,9 +5221,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -5651,9 +5651,9 @@
       }
     },
     "node_modules/semantic-release/node_modules/locate-path": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.1.1.tgz",
-      "integrity": "sha512-vJXaRMJgRVD3+cUZs3Mncj2mxpt5mP0EmNOsxRSZRMlbqjvxzDEOIUWXGmavo0ZC9+tNZCBLQ66reA11nbpHZg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
       "dev": true,
       "dependencies": {
         "p-locate": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "release": "semantic-release"
   },
   "engines": {
-    "node": ">=16.0.0",
-    "npm": ">=8.0.0"
+    "node": ">=v18.14.0",
+    "npm": ">=9.4.2"
   },
   "repository": {
     "type": "git",
@@ -23,14 +23,14 @@
   "homepage": "https://github.com/kristof-mattei/autoheal-rs#readme",
   "devDependencies": {
     "@actions/tool-cache": "^2.0.1",
-    "@semantic-release/changelog": "^6.0.1",
+    "@semantic-release/changelog": "^6.0.2",
     "@semantic-release/commit-analyzer": "^9.0.2",
-    "@semantic-release/github": "^8.0.5",
+    "@semantic-release/github": "^8.0.7",
     "@semantic-release/release-notes-generator": "^10.0.3",
     "conventional-changelog-conventionalcommits": "^5.0.0",
-    "prettier": "^2.7.1",
-    "semantic-release": "^20.0.0",
-    "semver": "^7.3.7",
+    "prettier": "^2.8.4",
+    "semantic-release": "^20.1.0",
+    "semver": "^7.3.8",
     "serialize-error": "^11.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
- chore(deps): update actions-rs-plus/clippy-check digest to 4837f9b
- chore(deps): update rust:1.67.1 docker digest to 02a53e7
- chore(deps): update alpine docker tag to v3.17.2
- fix: hack version (?)
- fix: remove version, doesn't work for container > image
- chore(deps): update returntocorp/semgrep docker digest to a645506
- chore(deps): update github/codeql-action action to v2.2.4
- fix: set rangeStrategy
- chore(deps): update dependency semver to ^7.3.8
- chore(deps): update dependency prettier to ^2.8.4
- chore(deps): update semantic-release monorepo
- chore(deps): update npm to v9
- chore(deps): update node.js to v18
- fix: unset rangeStrategy, move to the renovate base config
