### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,12 +308,11 @@ jobs:
         run: |
           grcov $(find profiling -name "profile-*.profraw" -print) --source-dir . --binary-path ./target/debug/ --output-type lcov --branch --ignore-not-existing --llvm --keep-only "src/**" --keep-only "tests/**" --output-path ./reports/lcov.info
 
-      - name: Upload to CodeCov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+      - name: Upload to Coveralls
+        uses: coverallsapp/github-action@v2.2.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: reports
-          fail_ci_if_error: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: reports/lcov.info
 
       - name: Fail if tests failed
         shell: bash

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,8 +18,8 @@
             "args": [],
             "cwd": "${workspaceFolder}",
             "env": {
-                "RUST_BACKTRACE": "1",
-                "RUST_LOG": "autoheal_rs=trace"
+                "RUST_BACKTRACE": "full",
+                "RUST_LOG": "trace,autoheal_rs=trace"
             }
         },
         {
@@ -41,8 +41,8 @@
             "args": [],
             "cwd": "${workspaceFolder}",
             "env": {
-                "RUST_BACKTRACE": "1",
-                "RUST_LOG": "autoheal_rs=trace"
+                "RUST_BACKTRACE": "full",
+                "RUST_LOG": "trace,autoheal_rs=trace"
             }
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,7 @@
         {
             "type": "cargo",
             "command": "build",
-            "args": [],
+            "args": ["--workspace", "--all-targets", "--all-features"],
             "problemMatcher": ["$rustc"],
             "group": "build",
             "label": "Rust: cargo build"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,15 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
-dependencies = [
- "backtrace",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,7 +36,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 name = "autoheal-rs"
 version = "0.0.0-development"
 dependencies = [
- "anyhow",
+ "color-eyre",
  "futures-util",
  "hex",
  "http-body-util",
@@ -94,6 +85,43 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
 
 [[package]]
 name = "fnv"
@@ -289,6 +317,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,8 +482,8 @@ checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.2",
- "regex-syntax 0.7.3",
+ "regex-automata 0.3.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -457,13 +497,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -474,9 +514,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rustc-demangle"
@@ -702,6 +742,16 @@ checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ repository = "https://github.com/kristof-mattei/autoheal-rs"
 coverage = []
 
 [dependencies]
-anyhow = { version = "1.0.71", features = ["backtrace"] }
 hex = "0.4.3"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = [
@@ -42,6 +41,7 @@ url = { version = "2.4.0", features = ["expose_internals"] }
 hyper-util = { version = "0.0.0", default_features = false }
 pin-project-lite = "0.2.10"
 futures-util = "0.3.28"
+color-eyre = "0.6.2"
 
 # We compile the Docker container with musl to get a static library. Smaller, faster.
 # BUT that means that we need to include openssl

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -11,7 +11,7 @@ pub struct AppConfig {
 }
 
 impl AppConfig {
-    pub fn build() -> Result<AppConfig, anyhow::Error> {
+    pub fn build() -> Result<AppConfig, color_eyre::Report> {
         Ok(AppConfig {
             webhook_url: parse_optional_env_variable("WEBHOOK_URL")?,
             autoheal_container_label: parse_env_variable_with_default(

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Error};
+use color_eyre::eyre::bail;
 use http_body_util::BodyExt;
 use hyper::body::{Buf, Incoming};
 use hyper::{Method, Response, StatusCode};
@@ -26,7 +26,7 @@ impl Docker {
         }
     }
 
-    pub async fn get_container_info(&self) -> Result<Vec<ContainerInfo>, anyhow::Error> {
+    pub async fn get_container_info(&self) -> Result<Vec<ContainerInfo>, color_eyre::Report> {
         let path_and_query = format!("/containers/json?filters={}", self.encoded_filters);
 
         let response = self.send_request(&path_and_query, Method::GET).await?;
@@ -42,7 +42,7 @@ impl Docker {
         &self,
         container_id: &str,
         timeout: u32,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), color_eyre::Report> {
         let path_and_query = format!("/containers/{}/restart?t={}", container_id, timeout);
 
         let response = self.send_request(&path_and_query, Method::POST).await?;
@@ -63,7 +63,7 @@ impl Docker {
         &self,
         path_and_query: &str,
         method: Method,
-    ) -> Result<Response<Incoming>, Error> {
+    ) -> Result<Response<Incoming>, color_eyre::Report> {
         match &self.config.endpoint {
             Endpoint::Direct(url) => {
                 let stream = connect_tcp_stream(url).await?;

--- a/src/docker_config.rs
+++ b/src/docker_config.rs
@@ -14,14 +14,16 @@ pub enum Endpoint {
 }
 
 impl DockerConfig {
-    pub fn build() -> Result<DockerConfig, anyhow::Error> {
+    pub fn build() -> Result<DockerConfig, color_eyre::Report> {
         const TCP_START: &str = "tcp://";
         let mut docker_socket_or_uri = std::env::var_os("DOCKER_SOCK")
             .map_or_else(
                 || Ok(String::from("/var/run/docker.sock")),
                 OsString::into_string,
             )
-            .map_err(|err| anyhow::Error::msg(format!("Could not convert {:?} to String", err)))?;
+            .map_err(|err| {
+                color_eyre::Report::msg(format!("Could not convert {:?} to String", err))
+            })?;
 
         let curl_timeout = parse_env_variable_with_default("CURL_TIMEOUT", 30)?;
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -19,7 +19,7 @@ pub extern "C" fn sig_handler(signal: i32) {
     // RUNNING.store(false, Ordering::SeqCst);
 }
 
-fn set_up_handler(signum: c_int, handler: usize) -> Result<(), anyhow::Error> {
+fn set_up_handler(signum: c_int, handler: usize) -> Result<(), color_eyre::Report> {
     let sa = sigaction {
         sa_sigaction: handler,
         sa_flags: 0,
@@ -39,7 +39,7 @@ fn set_up_handler(signum: c_int, handler: usize) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-pub(crate) fn set_up_handlers() -> Result<(), anyhow::Error> {
+pub(crate) fn set_up_handlers() -> Result<(), color_eyre::Report> {
     set_up_handler(SIGPIPE, SIG_IGN)?;
     set_up_handler(SIGTERM, sig_handler as usize)?;
     set_up_handler(SIGINT, sig_handler as usize)?;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,12 +1,11 @@
 #[macro_export]
 macro_rules! wrap_and_report {
-    ($level:expr, $error:expr, $message:expr) => {
-        {
-            let wrapped = Into::<anyhow::Error>::into($error).context($message);
+    ($level:expr, $error:expr, $message:expr) => {{
+        let wrapped =
+            color_eyre::Report::wrap_err(Into::<color_eyre::Report>::into($error), $message);
 
-            tracing::event!($level, error = %wrapped, error = ?wrapped.source().unwrap());
+        tracing::event!($level, error = ?wrapped);
 
-            wrapped
-        }
-    };
+        wrapped
+    }};
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,8 @@ use docker::Docker;
 use docker_config::DockerConfig;
 use handlers::set_up_handlers;
 use tokio::time::sleep;
-use tracing::metadata::LevelFilter;
 use tracing::{info, Level};
+use tracing::metadata::LevelFilter;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
@@ -31,7 +31,9 @@ mod http_client;
 mod support;
 mod webhook;
 
-fn main() -> Result<Infallible, anyhow::Error> {
+fn main() -> Result<Infallible, color_eyre::Report> {
+    color_eyre::install()?;
+
     tracing_subscriber::fmt::Subscriber::builder()
         .with_env_filter(
             EnvFilter::builder()
@@ -50,7 +52,7 @@ fn main() -> Result<Infallible, anyhow::Error> {
     rt.block_on(healer())
 }
 
-async fn healer() -> Result<Infallible, anyhow::Error> {
+async fn healer() -> Result<Infallible, color_eyre::Report> {
     let name = env!("CARGO_PKG_NAME");
     let version = env!("CARGO_PKG_VERSION");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,8 @@ use docker::Docker;
 use docker_config::DockerConfig;
 use handlers::set_up_handlers;
 use tokio::time::sleep;
-use tracing::{info, Level};
 use tracing::metadata::LevelFilter;
+use tracing::{info, Level};
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -15,7 +15,9 @@ pub fn notify_webhook_success(
     container_short_id: &str,
     container_name: &str,
 ) {
-    let Some(webhook_url) = app_config.webhook_url.clone() else { return };
+    let Some(webhook_url) = app_config.webhook_url.clone() else {
+        return;
+    };
 
     let message = format!(
         "Container {} ({}) found to be unhealthy. Successfully restarted the container!",
@@ -33,7 +35,9 @@ pub fn notify_webhook_failure(
     container_short_id: &str,
     error: &color_eyre::Report,
 ) {
-    let Some(webhook_url) = app_config.webhook_url.clone() else { return };
+    let Some(webhook_url) = app_config.webhook_url.clone() else {
+        return;
+    };
 
     let message = format!(
         "Container {} ({}) found to be unhealthy. Failed to restart the container! Error: {:?}",

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -31,7 +31,7 @@ pub fn notify_webhook_failure(
     app_config: &AppConfig,
     container_name: &str,
     container_short_id: &str,
-    error: &anyhow::Error,
+    error: &color_eyre::Report,
 ) {
     let Some(webhook_url) = app_config.webhook_url.clone() else { return };
 
@@ -61,7 +61,7 @@ async fn notify_webhook_and_log(webhook_url: &Uri, text: String) {
     };
 }
 
-async fn notify_webhook(webhook_url: &Uri, text: &str) -> Result<(), anyhow::Error> {
+async fn notify_webhook(webhook_url: &Uri, text: &str) -> Result<(), color_eyre::Report> {
     let payload = json!({
         "text": text,
     });

--- a/update-name.sh
+++ b/update-name.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+
+NEW_NAME=$1
+
+FILTERED_NAME=$(echo "${NEW_NAME}" | sed -e "s/[a-z0-9-]//g")
+
+
+echo "New name = ${NEW_NAME}"
+
+
+if [[ ${#FILTERED_NAME} != 0 ]]; then
+    echo "Name only allows [a-z0-9-], found ${FILTERED_NAME} (length = ${#FILTERED_NAME})"
+    exit 1
+fi
+
+
+NEW_NAME_WITH_UNDERSCORE=$(echo "${NEW_NAME}" | sed -e "s/-/_/g")
+
+echo "New name with underscore = ${NEW_NAME_WITH_UNDERSCORE}"
+
+
+P1="rust-end-to-end-"
+OLD_NAME="${P1}application"
+OLD_NAME_WITH_UNDERSCORE=$(echo "${OLD_NAME}" | sed -e "s/-/_/g")
+
+echo ${OLD_NAME_WITH_UNDERSCORE}
+
+
+rg --hidden --files-with-matches ${OLD_NAME} | xargs -i sed -i "s/${OLD_NAME}/${NEW_NAME}/g" {}
+rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE}
+rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE} | xargs -i sed -i "s/${OLD_NAME_WITH_UNDERSCORE}/${NEW_NAME_WITH_UNDERSCORE}/g" {}


### PR DESCRIPTION
- chore(deps): update alpine:3.18.2 docker digest to 5246eec
- chore(deps): update alpine:3.18.2 docker digest to 82d1e9d
- chore(deps): update mcr.microsoft.com/devcontainers/rust docker tag to v1
- chore(deps): update dependency semver to ^7.5.2
- fix: also do RUST_BACKTRACE=full for debugging
- chore(deps): update dependency conventional-changelog-conventionalcommits to ^6.1.0
- chore(deps): lock file maintenance
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.8.0
- chore(deps): update node.js to >=v18.16.1
- chore(deps): update returntocorp/semgrep docker tag to v1.28.0
- chore(deps): update github/codeql-action action to v2.20.1
- chore(deps): update npm to >=9.7.2
- chore(deps): update dependency semver to ^7.5.3
- fix: build all with tests too
- fix: trace for all, not just the app
- fix: default is to use color-eyre
- fix: trace for run and test
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.29.0
- chore(deps): update docker/setup-buildx-action action to v2.8.0
- chore(deps): update returntocorp/semgrep docker tag to v1.30.0
- chore(deps): update dependency semantic-release to ^21.0.6
- chore(deps): lock file maintenance
- chore(deps): update github/codeql-action action to v2.20.2
- chore(deps): update rust:1.70.0 docker digest to d3283ba
- chore(deps): update rust:1.70.0 docker digest to a8d4f44
- chore(deps): update rust:1.70.0 docker digest to 28ee882
- chore(deps): update dependency @semantic-release/release-notes-generator to ^11.0.4
- chore(deps): update dependency semantic-release to ^21.0.7
- chore(deps): update rust:1.70.0 docker digest to dbdf889
- chore(deps): update actions/setup-node action to v3.7.0
- chore(deps): update npm to >=9.8.0
- chore(deps): update github/codeql-action action to v2.20.3
- chore(deps): update dependency prettier to v3
- fix: add update-name script
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to b732d41
- chore(deps): update docker/setup-buildx-action action to v2.9.0
- chore(deps): update returntocorp/semgrep docker tag to v1.31.1
- chore(deps): update dependency semver to ^7.5.4
- chore(deps): update returntocorp/semgrep docker tag to v1.31.2
- chore(deps): lock file maintenance
- chore(deps): update docker/setup-buildx-action action to v2.9.1
- fix: Coveralls as CodeCov keeps on failing
- fix: specify version, Renovate will pin it
- chore(deps): update github/codeql-action action to v2.20.4
