### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,12 +133,12 @@ jobs:
         run: |
           VERSION="$(cog bump --auto --dry-run || true)"
 
-          if [[ -z $VERSION ]]; then
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "New version: ${VERSION}"
+          else
               VERSION="$(git tag --points-at "$(git rev-list --tags --max-count=1)" | sort --reverse | head --lines 1)"
 
               echo "No version generated, defaulting to latest git tag: ${VERSION}"
-          else
-              echo "New version: ${VERSION}"
           fi
 
           # remove v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ concurrency:
 
 on:
   workflow_dispatch: # releasing is manual as we don't want to release every time
-    branches: [main]
 
 permissions:
   contents: write # to write tags

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+20

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -43,6 +43,9 @@
             "type": "cargo",
             "command": "test",
             "args": [],
+            "env": {
+                "RUSTFLAGS": "-Wclippy::all -Wclippy::pedantic -Wclippy::cargo -Wwarnings"
+            },
             "problemMatcher": ["$rustc"],
             "group": "test",
             "label": "Rust: cargo test"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ repository = "https://github.com/kristof-mattei/autoheal-rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.dev.package.backtrace]
+opt-level = 3
+
 [features]
 coverage = []
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,17 @@ ARG APPLICATION_NAME
 
 RUN rustup target add ${TARGET}
 
-RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache
 
 # borrowed (Ba Dum Tss!) from
 # https://github.com/pablodeymo/rust-musl-builder/blob/7a7ea3e909b1ef00c177d9eeac32d8c9d7d6a08c/Dockerfile#L48-L49
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
-    apt-get update && \
+    apt-get update &&
     apt-get --no-install-recommends install -y \
-    build-essential \
-    musl-dev \
-    musl-tools
+        build-essential \
+        musl-dev \
+        musl-tools
 
 # The following block
 # creates an empty app, and we copy in Cargo.toml and Cargo.lock as they represent our dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,16 @@ ARG APPLICATION_NAME
 
 RUN rustup target add ${TARGET}
 
-RUN rm -f /etc/apt/apt.conf.d/docker-clean
-echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
 # borrowed (Ba Dum Tss!) from
 # https://github.com/pablodeymo/rust-musl-builder/blob/7a7ea3e909b1ef00c177d9eeac32d8c9d7d6a08c/Dockerfile#L48-L49
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
-    apt-get update &&
+    apt-get update && \
     apt-get --no-install-recommends install -y \
-        build-essential \
-        musl-dev \
-        musl-tools
+    build-essential \
+    musl-dev \
+    musl-tools
 
 # The following block
 # creates an empty app, and we copy in Cargo.toml and Cargo.lock as they represent our dependencies


### PR DESCRIPTION
- chore(deps): update actions/upload-artifact action to v3.1.3
- chore(deps): update returntocorp/semgrep docker tag to v1.39.0
- chore(deps): update rust:1.72.0 docker digest to b166ff9
- chore(deps): update coverallsapp/github-action action to v2.2.3
- chore(deps): update rust:1.72.0 docker digest to 535b72c
- chore(deps): update rust:1.72.0 docker digest to fb4f69b
- chore(deps): update rust:1.72.0 docker digest to 8a4ca3c
- chore(deps): update docker/build-push-action action to v4.2.0
- chore(deps): update docker/build-push-action action to v4.2.1
- chore(deps): update actions/cache action to v3.3.2
- chore(deps): update dependency conventional-changelog-conventionalcommits to ^7.0.2
- chore(deps): update npm to v10
- chore(deps): update dependency @semantic-release/github to ^9.0.5
- chore(deps): lock file maintenance
- chore(deps): update docker/setup-buildx-action action to v3
- chore(deps): update docker/login-action action to v3
- chore(deps): update docker/metadata-action action to v5
- chore(deps): update docker/build-push-action action to v5
- chore(deps): update github/codeql-action action to v2.21.6
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 3d6ac10
- chore(deps): update github/codeql-action action to v2.21.7
- chore(deps): update dependency @semantic-release/github to ^9.0.6
- chore(deps): update returntocorp/semgrep docker tag to v1.40.0
- chore(deps): update dependency semantic-release to ^21.1.2
- chore(deps): lock file maintenance
- chore(deps): update dependency semantic-release to v22
- chore(deps): update semantic-release monorepo
- chore(deps): update node.js to >=v18.18.0
- chore(deps): update returntocorp/semgrep docker tag to v1.41.0
- chore(deps): update github/codeql-action action to v2.21.8
- chore(deps): update rust docker tag to v1.72.1
- chore(deps): update rust to v1.72.1
- chore(deps): update rust:1.72.1 docker digest to 1a03e33
- chore(deps): update rust:1.72.1 docker digest to 0935c74
- chore(deps): update rust:1.72.1 docker digest to d601f6c
- chore(deps): update dependency semantic-release to ^22.0.1
- chore(deps): update rust:1.72.1 docker digest to 911acdf
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.10.0
- chore(deps): update actions/checkout action to v4.1.0
- chore(deps): update dependency semantic-release to ^22.0.4
- chore(deps): update dependency @semantic-release/github to ^9.0.7
- chore(deps): update dependency semantic-release to ^22.0.5
- chore(deps): lock file maintenance
- chore(deps): update dependency @semantic-release/github to ^9.1.0
- chore(deps): update dependency @semantic-release/github to ^9.2.0
- chore(deps): update github/codeql-action action to v2.21.9
- chore(deps): update dependency @semantic-release/github to ^9.2.1
- chore(deps): update actions-rs-plus/clippy-check action to v2.1.1
- fix: workflow_dispatch does not take a branch
- chore(deps): update alpine docker tag to v3.18.4
- chore(deps): update returntocorp/semgrep docker tag to v1.42.0
- chore(deps): lock file maintenance
- chore(deps): update npm to >=10.2.0
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 05a0d13
- chore(deps): update returntocorp/semgrep docker tag to v1.43.0
- chore(deps): update rust to v1.73.0
- chore(deps): update github/codeql-action action to v2.22.0
- chore(deps): lock file maintenance
- chore(deps): update github/codeql-action action to v2.22.1
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.11.0
- chore(deps): update node.js to >=18.18.1
- chore(deps): update returntocorp/semgrep docker tag to v1.44.0
- chore(deps): update github/codeql-action action to v2.22.2
- chore(deps): update rust:1.73.0 docker digest to 1fd670f
- chore(deps): update rust:1.73.0 docker digest to 0b82242
- chore(deps): update rust:1.73.0 docker digest to 054d687
- chore(deps): update rust:1.73.0 docker digest to 73af736
- chore(deps): update github/codeql-action action to v2.22.3
- chore(deps): update node.js to >=18.18.2
- chore(deps): lock file maintenance
- chore(deps): update actions/checkout action to v4.1.1
- chore(deps): pin dependencies
- chore(deps): update npm to >=10.2.1
- chore(deps): update returntocorp/semgrep docker tag to v1.45.0
- chore(deps): update github/codeql-action action to v2.22.4
- chore(deps): lock file maintenance
- chore(deps): update actions/setup-node action to v3.8.2
- chore(deps): update actions/setup-node action to v4
- chore(deps): update node.js to v20
- chore(deps): update node.js to >=20.9.0
- chore(deps): update returntocorp/semgrep docker tag to v1.46.0
- chore: move to node 20, make backtrace always compile release as we don't care about their internals
- chore(deps): update github/codeql-action action to v2.22.5
- chore(deps): lock file maintenance
- chore(deps): update dependency semantic-release to v22.0.6
- chore(deps): update npm to >=10.2.2
- chore(deps): update rust:1.73.0 docker digest to 0dc5fcb
- chore(deps): update rust:1.73.0 docker digest to 4e0bd79
- chore(deps): update rust:1.73.0 docker digest to 25fa7a9
- chore(deps): update returntocorp/semgrep docker tag to v1.47.0
- fix: fix new version
