### PR TITLE
update from upstream

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -8,7 +8,7 @@ overrides:
       - "**/*.json"
     options:
       tabWidth: 4
-      trailingComma: all
+      trailingComma: none
   - files:
       - "package.json"
       - "package-lock.json"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@semantic-release/github": "9.2.6",
         "@semantic-release/release-notes-generator": "12.1.0",
         "conventional-changelog-conventionalcommits": "7.0.2",
-        "prettier": "3.2.2",
+        "prettier": "3.2.3",
         "semantic-release": "23.0.0"
       },
       "engines": {
@@ -5260,9 +5260,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.2.tgz",
-      "integrity": "sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.3.tgz",
+      "integrity": "sha512-QNhUTBq+mqt1oH1dTfY3phOKNhcDdJkfttHI6u0kj7M2+c+7fmNKlgh2GhnHiqMcbxJ+a0j2igz/2jfl9QKLuw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@semantic-release/github": "9.2.6",
     "@semantic-release/release-notes-generator": "12.1.0",
     "conventional-changelog-conventionalcommits": "7.0.2",
-    "prettier": "3.2.2",
+    "prettier": "3.2.3",
     "semantic-release": "23.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
- chore(deps): update rust:1.75.0 docker digest to c09b1bb
- chore(deps): update dependency prettier to v3.2.2
- chore(deps): lock file maintenance
- chore(deps): update rust:1.75.0 docker digest to b168e2c
- chore(deps): update rust:1.75.0 docker digest to 184a309
- chore: no trailing commas in json
- chore(deps): update dependency prettier to v3.2.3
