### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -34,8 +34,17 @@ jobs:
         run: |
           semgrep ci --sarif --output=semgrep.sarif
 
+      - name: Fixup semgrep.sarif's startColumn==0 and/or endColumn==0
+        shell: bash
+        run: |
+          jq '.' semgrep.sarif > normalized.sarif
+          jq 'del(.runs[].results[].locations[].physicalLocation.region | select(.startColumn==0) | .startColumn)' normalized.sarif > fixed_start_column.sarif
+          jq 'del(.runs[].results[].locations[].physicalLocation.region | select(.endColumn==0) | .endColumn)' fixed_start_column.sarif > fixed_start_end_column.sarif
+
+          diff normalized.sarif fixed_start_end_column.sarif || true
+
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
         uses: github/codeql-action/upload-sarif@e675ced7a7522a761fc9c8eb26682c8b27c42b2b # v3.24.1
         with:
-          sarif_file: semgrep.sarif
+          sarif_file: fixed_start_end_column.sarif

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,autoheal_rs=TRACE"
             },
-            "terminal": "integrated"
+            "internalConsoleOptions": "openOnSessionStart",
+            "terminal": "console"
         },
         {
             "type": "lldb",
@@ -45,7 +46,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,autoheal_rs=TRACE"
             },
-            "terminal": "integrated"
+            "internalConsoleOptions": "openOnSessionStart",
+            "terminal": "console"
         },
         {
             "type": "lldb",
@@ -69,7 +71,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,autoheal_rs=TRACE"
             },
-            "terminal": "integrated"
+            "internalConsoleOptions": "openOnSessionStart",
+            "terminal": "console"
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,13 @@
 {
     "rust-analyzer.runnables.extraEnv": {
         "RUST_LOG": "DEBUG,autoheal_rs=TRACE"
-    }
+    },
+    "rust-analyzer.debug.openDebugPane": true,
+    "rust-analyzer.debug.engineSettings": {
+        "lldb": {
+            "internalConsoleOptions": "openOnSessionStart",
+            "terminal": "console"
+        }
+    },
+    "debug.internalConsoleOptions": "openOnSessionStart"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,9 +237,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "hex"
@@ -595,9 +595,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "proc-macro2"


### PR DESCRIPTION
- chore(deps): update rust:1.75.0 docker digest to 2176747
- chore(deps): update rust:1.75.0 docker digest to 166aa82
- chore(deps): update rust:1.75.0 docker digest to ac8c4cb
- chore(deps): update returntocorp/semgrep docker tag to v1.57.0
- chore(deps): update actions/upload-artifact action to v4.2.0
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.58.0
- chore(deps): update actions/upload-artifact action to v4.3.0
- chore(deps): update dorny/paths-filter action to v2.12.0
- chore(deps): update npm to >=10.4.0
- chore(deps): update dorny/paths-filter action to v3
- chore(deps): update github/codeql-action action to v3.23.2
- chore(deps): update alpine docker tag to v3.19.1
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.59.0
- chore(deps): update docker/metadata-action action to v5.5.1
- chore(deps): update rust:1.75.0 docker digest to 503aee4
- chore(deps): update rust:1.75.0 docker digest to e173089
- chore(deps): update rust:1.75.0 docker digest to fb477b5
- chore(deps): update returntocorp/semgrep docker tag to v1.59.1
- chore(deps): update github/codeql-action action to v3.24.0
- chore: use internal console, not the terminal for debugging
- chore(deps): update rust:1.75.0 docker digest to 87f3b2f
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.13.0
- chore(deps): update dependency prettier to v3.2.5
- chore(deps): lock file maintenance
- chore(deps): update actions/download-artifact action to v4.1.2
- chore(deps): update actions/upload-artifact action to v4.3.1
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.14.0
- chore(deps): update dependency semantic-release to v23.0.1
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 64161ff
- chore(deps): update actions/setup-node action to v4.0.2
- chore(deps): update dependency semantic-release to v23.0.2
- chore(deps): update rust to v1.76.0
- chore(deps): update returntocorp/semgrep docker tag to v1.60.1
- chore(deps): update rust:1.76.0 docker digest to 8e87602
- chore(deps): lock file maintenance
- chore(deps): update github/codeql-action action to v3.24.1
- chore(deps): update rust:1.76.0 docker digest to 3e95fdb
- chore(deps): update returntocorp/semgrep docker tag to v1.61.0
- chore(deps): update rust:1.76.0 docker digest to 01752fc
- chore(deps): update rust:1.76.0 docker digest to 3c1dc1b
- chore: fix startColumn/endColumn being 0. Is invalid. Normalize json file for diffing, ignore output. Diff is expected
- chore(deps): update node.js to >=20.11.1
