### PR TITLE
aarch64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -417,9 +417,8 @@ jobs:
         platform:
           - docker: linux/amd64
             rust: x86_64-unknown-linux-musl
-          # musl on arm64 is blocked until https://github.com/rust-lang/rust/issues/89626 is in stable
-          # - docker: linux/arm64
-          #   rust: aarch64-unknown-linux-musl
+          - docker: linux/arm64
+            rust: aarch64-unknown-linux-musl
     steps:
       - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
     build-essential \
     musl-dev \
     musl-tools \
-    gcc-aarch64-linux-gnu
+    gcc-multilib
 
 # The following block
 # creates an empty app, and we copy in Cargo.toml and Cargo.lock as they represent our dependencies


### PR DESCRIPTION
- **chore(deps): update github/codeql-action action to v3.24.10**
- **chore(deps): update dependency @semantic-release/github to v10.0.3**
- **chore(deps): lock file maintenance**
- **chore(deps): update docker/setup-buildx-action action to v3.3.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.68.0**
- **chore(deps): update codecov/codecov-action action to v4.3.0**
- **chore(deps): update dependency semantic-release to v23.0.8**
- **chore: linker for aarch64**
- **chore: copy in linker into docker container**
- **chore(deps): update node.js to >=20.12.2**
- **chore(deps): update npm to >=10.5.2**
- **fix: correctly build musl**
- **chore(deps): update rust to v1.77.2**
- **chore: re-enable aarch64**
