### PR TITLE
update from upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,18 +84,9 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "bitflags"
 version = "2.6.0"
-||||||| ce6b548
-name = "cc"
-version = "1.0.103"
-=======
-name = "cc"
-version = "1.1.10"
->>>>>>> upstream/main
 source = "registry+https://github.com/rust-lang/crates.io-index"
-<<<<<<< HEAD
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
@@ -106,13 +97,12 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-||||||| ce6b548
-checksum = "2755ff20a1d93490d26ba33a6f092a38a508398a5320df5d4b3014fcccce9410"
-=======
->>>>>>> upstream/main
-checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
+checksum = "5fb8dd288a69fc53a1996d7ecfbf4a20d59065bff137ce7e56bbd620de191189"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -459,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -782,6 +772,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,15 +905,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"


### PR DESCRIPTION
- **chore(deps): update actions/download-artifact action to v4.1.8**
- **chore(deps): update actions/upload-artifact action to v4.3.4**
- **chore(deps): update rui314/setup-mold digest to 2e332a0**
- **chore(deps): lock file maintenance**
- **chore(deps): update dependency @semantic-release/github to v10.1.0**
- **chore(deps): update dependency node to v20.15.1**
- **chore(deps): update actions/setup-node action to v4.0.3**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to be2a4d1**
- **chore(deps): update returntocorp/semgrep docker tag to v1.79.0**
- **chore(deps): update npm to >=10.8.2**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.17.0**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 6a4b1fa**
- **chore(deps): update github/codeql-action action to v3.25.12**
- **chore(deps): update dependency prettier to v3.3.3**
- **chore(deps): lock file maintenance**
- **chore(deps): lock file maintenance**
- **chore(deps): update docker/build-push-action action to v6.4.0**
- **chore(deps): update docker/build-push-action action to v6.4.1**
- **chore(deps): update returntocorp/semgrep docker tag to v1.80.0**
- **chore(deps): update github/codeql-action action to v3.25.13**
- **chore(deps): update dependency @semantic-release/github to v10.1.1**
- **chore(deps): lock file maintenance**
- **chore(deps): update docker/build-push-action action to v6.5.0**
- **chore(deps): update docker/setup-buildx-action action to v3.5.0**
- **chore(deps): update docker/login-action action to v3.3.0**
- **chore(deps): update alpine docker tag to v3.20.2**
- **chore(deps): update alpine:3.20.2 docker digest to 0a4eaa0**
- **chore(deps): update rust:1.79.0 docker digest to eb24e74**
- **chore(deps): update dependency node to v20.16.0**
- **chore(deps): update rust:1.79.0 docker digest to 6ed1f22**
- **chore(deps): update returntocorp/semgrep docker tag to v1.81.0**
- **chore(deps): update rust:1.79.0 docker digest to 9b2689d**
- **chore(deps): update github/codeql-action action to v3.25.14**
- **chore(deps): update dependency @semantic-release/github to v10.1.2**
- **chore(deps): update dependency @semantic-release/github to v10.1.3**
- **chore(deps): update rust to v1.80.0**
- **chore(deps): update rust:1.80.0 docker digest to fcbb950**
- **chore(deps): update github/codeql-action action to v3.25.15**
- **chore(deps): lock file maintenance**
- **chore(deps): update docker/setup-buildx-action action to v3.6.0**
- **chore(deps): update docker/setup-buildx-action action to v3.6.1**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.82.0**
- **chore(deps): update actions/upload-artifact action to v4.3.5**
- **chore(deps): update returntocorp/semgrep docker tag to v1.83.0**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/upload-artifact action to v4.3.6**
- **chore(deps): update github/codeql-action action to v3.26.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.84.0**
- **chore(deps): update docker/build-push-action action to v6.6.0**
- **chore(deps): update docker/build-push-action action to v6.6.1**
- **chore(deps): update returntocorp/semgrep docker tag to v1.84.1**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 569f65d**
- **chore(deps): update rust docker tag to v1.80.1**
- **chore(deps): update rust:1.80.1 docker digest to 606b76f**
- **chore(deps): update dependency @semantic-release/github to v10.1.4**
- **chore(deps): lock file maintenance**
- **chore(deps): update rust:1.80.1 docker digest to 536c1a4**
- **chore(deps): update docker/build-push-action action to v6.7.0**
- **chore(deps): update github/codeql-action action to v3.26.1**
- **chore(deps): update rust:1.80.1 docker digest to 5890069**
- **chore(deps): update rust:1.80.1 docker digest to 29fe437**
- **chore(deps): update github/codeql-action action to v3.26.2**
- **chore: syntax consistency, as -> AS**
