### PR TITLE
update from upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".vscode/rust-prettifier-for-lldb"]
+	path = .vscode/rust-prettifier-for-lldb
+	url = https://github.com/cmrschwarz/rust-prettifier-for-lldb

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 .git
-.github/actions/
+.mypy_cache
+.vscode/rust-prettifier-for-lldb
 CHANGELOG.md
 profiling
 reports

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,8 +21,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,autoheal_rs=TRACE"
             },
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
+            "internalConsoleOptions": "neverOpen",
+            "terminal": "integrated"
         },
         {
             "type": "lldb",
@@ -46,8 +46,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,autoheal_rs=TRACE"
             },
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
+            "internalConsoleOptions": "neverOpen",
+            "terminal": "integrated"
         },
         {
             "type": "lldb",
@@ -71,8 +71,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,autoheal_rs=TRACE"
             },
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
+            "internalConsoleOptions": "neverOpen",
+            "terminal": "integrated"
         }
     ]
 }

--- a/.vscode/rust_prettifier_for_lldb.py
+++ b/.vscode/rust_prettifier_for_lldb.py
@@ -1,0 +1,1 @@
+./rust-prettifier-for-lldb/rust_prettifier_for_lldb.py

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,11 @@
 {
-    "debug.internalConsoleOptions": "openOnSessionStart",
+    "debug.internalConsoleOptions": "neverOpen",
+    "lldb.launch.terminal": "integrated",
+    "lldb.launch.expressions": "simple",
+    "lldb.launch.preRunCommands": [
+        "command script import ${workspaceFolder}/.vscode/rust_prettifier_for_lldb.py"
+    ],
     "prettier.configPath": "./.prettierrc.cjs",
-    "rust-analyzer.debug.engineSettings": {
-        "lldb": {
-            "internalConsoleOptions": "openOnSessionStart",
-            "terminal": "console"
-        }
-    },
-    "rust-analyzer.debug.openDebugPane": true,
     "rust-analyzer.runnables.extraEnv": {
         "RUST_LOG": "DEBUG,autoheal_rs=TRACE"
     }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,9 +202,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "shlex",
 ]
@@ -455,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1199,7 +1199,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1398,9 +1398,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1509,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1889,18 +1889,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
- **chore(deps): update rust:1.86.0 docker digest to 563b33d**
- **chore(deps): update dependency prettier-plugin-sh to v0.16.1**
- **chore(deps): lock file maintenance**
- **chore(deps): update github/codeql-action action to v3.28.14**
- **chore(deps): update github/codeql-action action to v3.28.15**
- **chore(deps): update rust:1.86.0 docker digest to 2494472**
- **chore(deps): update rust:1.86.0 docker digest to 6a6dda6**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.0**
- **chore(deps): update npm to >=11.3.0**
- **chore(deps): update rust:1.86.0 docker digest to 9fdf93f**
- **chore(deps): update rust:1.86.0 docker digest to 7b65306**
- **chore(deps): update returntocorp/semgrep docker tag to v1.118.0**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.1**
- **chore(deps): update dependency prettier-plugin-sh to v0.17.2**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to a87c2e8**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/setup-node action to v4.4.0**
- **chore(deps): update codecov/codecov-action action to v5.4.2**
- **chore(deps): update returntocorp/semgrep docker tag to v1.119.0**
- **chore(deps): update softprops/action-gh-release action to v2.2.2**
- **chore(deps): lock file maintenance**
- **fix: start tracking lldb debug helper**
- **chore(deps): update returntocorp/semgrep docker tag to v1.120.0**
- **chore(deps): update github/codeql-action action to v3.28.16**
- **chore(deps): update node.js to v22.15.0**
- **chore(deps): update docker/build-push-action action to v6.16.0**
- **chore(deps): update actions/download-artifact action to v4.3.0**
- **chore: set default debug visualizer**
- **chore: update debug setup**
