### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,6 +531,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         if: fromJSON(steps.setup_qemu.outputs.setup_qemu) == true
+        with:
+          platforms: linux/${{ matrix.platform }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1


### PR DESCRIPTION
- **chore(deps): update pnpm to v10.17.1**
- **chore(deps): update returntocorp/semgrep docker tag to v1.137.1**
- **chore(deps): update actions/cache action to v4.3.0**
- **chore(deps): update github/codeql-action action to v3.30.4**
- **chore(deps): update returntocorp/semgrep docker tag to v1.138.0**
- **chore(deps): update node.js to v24.9.0**
- **chore(deps): update github/codeql-action action to v3.30.5**
- **chore: use slim-trixie instead of trixie**
- **chore(deps): pin rust docker tag to 40d4ee1**
- **chore(ci): add step that builds cargo-edit and cargo-get before the docker build. Docker build will then pick up cached version**
- **chore(ci): add comment ensuring the non-standard action gets updated**
- **chore(ci): split builds again for speed**
